### PR TITLE
Adding column drs.group_database_id to AG DatabaseQuery

### DIFF
--- a/DiagManager/CustomDiagnostics/AlwaysOn Basic Info/AlwaysOnDiagScript.sql
+++ b/DiagManager/CustomDiagnostics/AlwaysOn Basic Info/AlwaysOnDiagScript.sql
@@ -189,6 +189,7 @@ PRINT ''
 select 
 database_name=cast(drcs.database_name as varchar(30)), 
 drs.database_id,
+drs.group_database_id,
 drs.group_id,
 drs.replica_id,
 drs.is_local,


### PR DESCRIPTION
drs.group_database_id is an essential DB identification token in all advanced AAG Xevents, not having it in AAG metadata script is blocking
(many events with only this id populated, and empty dbname/dbid, eg hadr_db_manager_db_startdb)