### PR TITLE
Fix: SqlNexus link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 ## What is Pssdiag/Sqldiag Manager?
-Pssdiag/Sqldiag Manager is a graphic interface that provides customization capabilities to collect data for SQL Server using sqldiag collector engine. The data collected can be used by [SQL Nexus tool](http://sqlnexus.codeplex.com/)  which help you troubleshoot SQL Server performance problems.  This is the same tool Microsoft SQL Server support engineers use to for data collection to troubleshoot customer's performance problems.
+Pssdiag/Sqldiag Manager is a graphic interface that provides customization capabilities to collect data for SQL Server using sqldiag collector engine. The data collected can be used by [SQL Nexus tool](https://github.com/Microsoft/SqlNexus)  which help you troubleshoot SQL Server performance problems.  This is the same tool Microsoft SQL Server support engineers use to for data collection to troubleshoot customer's performance problems.
 
 ## Current Release
  Build 15.0.0001.12


### PR DESCRIPTION
SqlNexus is no longer hosted on Codeplex ; the link must be updated.