### PR TITLE
diagutil.exe and config files deleted

### DIFF
--- a/DiagManager/DiagManager.csproj
+++ b/DiagManager/DiagManager.csproj
@@ -312,9 +312,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Icon.ico" />
-    <Content Include="Pristine\DiagUtil.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="Pristine\MSDiagProcs.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -478,9 +475,6 @@
     <Content Include="Pristine\Confirm-FileAttributes.ps1">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <None Include="Pristine\DiagUtil.exe.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <Content Include="Pristine\pssdiag.ps1">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -1393,16 +1387,6 @@
       <FileType>File</FileType>
     </PublishFile>
     <PublishFile Include="Pristine\Confirm-FileAttributes.ps1">
-      <Visible>False</Visible>
-      <Group>
-      </Group>
-      <TargetPath>
-      </TargetPath>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
-      <FileType>File</FileType>
-    </PublishFile>
-    <PublishFile Include="Pristine\DiagUtil.exe">
       <Visible>False</Visible>
       <Group>
       </Group>

--- a/DiagManager/Pristine/DiagUtil.exe.config
+++ b/DiagManager/Pristine/DiagUtil.exe.config
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<configuration>
-	<startup>
-    <supportedRuntime version="v2.0"/>
-    <supportedRuntime version="v4.0"/>
-  </startup>
-</configuration>

--- a/diagutil/DiagUtil.csproj
+++ b/diagutil/DiagUtil.csproj
@@ -43,6 +43,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>SecurityRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -102,7 +103,8 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Y "$(TargetDir)DiagUtil.exe" "$(SolutionDir)DiagManager\Pristine"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
was removed the files and the property on DiagUtil project that xcopy the exe file

Fixes
Deleted diagutil.exe and diagutil.exe.config files from project.
Remove xcopy that was adding the file to pristine folder.

Changes proposed in this pull request:
Stop adding DiagUtil.exe on the solution.

How to test this code:
Create PSSDIAG.zip

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - SQL Server 2017
 - SQL Server 2019
 - Azure SQL Virtual Machine
 - Amazon RDS
 
