### PR TITLE
remove AlwaysOnGetClusterLogs.cmd #203

### DIFF
--- a/DiagManager/CustomDiagnostics/AlwaysOn Basic Info/AlwaysOnGetClusterLogs.cmd
+++ b/DiagManager/CustomDiagnostics/AlwaysOn Basic Info/AlwaysOnGetClusterLogs.cmd
@@ -1,1 +1,0 @@
-%systemroot%\System32\WindowsPowerShell\v1.0\powershell.exe import-module failoverclusters; get-clusterlog -Destination %1 -UseLocalTime


### PR DESCRIPTION
We are not using the file, so removing it.

Fixes # 203.

Changes proposed in this pull request: Removed the aysOnGetClusterLogs.cmd 

How to test this code: None
Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - SQL Server 2017
 - SQL Server 2019
 - Azure SQL Virtual Machine
 - Amazon RDS
 
