### PR TITLE
[PSSDIAG] Reduce the collection of unnecessary ERRORLOG

### DIFF
--- a/DiagManager/CustomDiagnostics/SQL Base/get_errorlogs.ps1
+++ b/DiagManager/CustomDiagnostics/SQL Base/get_errorlogs.ps1
@@ -40,6 +40,7 @@ $vLogPath = (Get-ItemProperty -Path HKLM:$vRegPath).SQLArg1 -replace '-e'
 $vLogPath = $vLogPath -replace 'ERRORLOG'
 
 Write-Output "The \LOG folder discovered is: $vLogPath"
+Write-Output "*************************************************"
 
 
 #build a ""server_instance"" string from "server\instance" string
@@ -52,10 +53,23 @@ foreach ($file in $ErrlogFiles)
 {
    $source = $file.FullName
    $destination = $DestinationFolder + $server_instance + "_" + $file.Name
+   $destination_head_tail = $DestinationFolder + $server_instance + "_" + $file.Name + "_Head_and_Tail_Only"
 
-   Copy-Item -Path  $source  -Destination  $destination  | Out-Null
+   if ($file.Length -ge 1073741824)
+   {
+     Write-Output $destination_head_tail
+     Get-Content $source -TotalCount 300 | Set-Content -Path $destination_head_tail | Out-Null
+     Add-Content -Value "`n   <<... middle part of file not captured because the file is too large (>1 GB) ...>>`n" -Path $destination_head_tail | Out-Null
+     Get-Content $source -Tail 300 | Add-Content -Path $destination_head_tail | Out-Null
+   }
+   elseif ($file.Length -gt 0)
+   {
+     Write-Output $destination
+     Copy-Item -Path $source -Destination  $destination | Out-Null
+   }
 }
 
+Write-Output "*************************************************"
 
 # Copying SQLAGENT files
 $SQLAgentlogFiles = Get-ChildItem -File -Path $vLogPath -Filter "SQLAGENT*" 
@@ -67,4 +81,7 @@ foreach ($file in $SQLAgentlogFiles)
    $destination = $DestinationFolder + $server_instance + "_" + $file.Name
 
    Copy-Item -Path  $source  -Destination  $destination  | Out-Null
+   Write-Output $destination
 }
+
+Write-Output "*************************************************"


### PR DESCRIPTION
Fixes # None

Changes proposed in this pull request:
Feature - reduce the collection of unnecessary ERRORLOG info by PSSDIAG.
If the ERRORLOG is >= 1GB in size only the first 300 lines and the last 300 lines will be captured. 

What is the current behavior?
We currently get entire files even if they are 2 MB or 100 GB is size

Which versions of SQL Server and which OS are affected by this issue? Did this work in previous versions of our procedures?
All versions

How to test this code:
 - From Custom Diagnostics -> SQL Base -> Errorlog_All at Shutdown
 - Log files are saved to the output folder

Has been tested on (remove any that don't apply):
 - SQL Server 2019
 
