### PR TITLE
Setting @AppName from "Test" to "Trace".

### DIFF
--- a/LinuxDiag/pssdiag_trace_stop.sql
+++ b/LinuxDiag/pssdiag_trace_stop.sql
@@ -1,4 +1,4 @@
 -- this stored procedure is created from MSDiagprocs.sql
 -- please make sure that script runs before launching this
 
-EXEC tempdb.dbo.sp_trace13 'OFF',@AppName='SQLDIAG_Test_*',@TraceName='tsqltrace'
+EXEC tempdb.dbo.sp_trace13 'OFF',@AppName='SQLDIAG_Trace_*',@TraceName='tsqltrace'


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 -  Change the AppName in the stop trace script from using "Test" to "Trace", to correctly stop the SQL Trace.

How to test this code:
 -  Start a capture
 -  Verify that the trace is running.
 -  Stop capture
 - Verify that the trace stopped.

Has been tested on (remove any that don't apply):
 - SQL Server 2019

