### PR TITLE
- Corrected typos on the welcome screen and in log names.

### DIFF
--- a/LinuxDiag/SQL_Perf_Stats.sql
+++ b/LinuxDiag/SQL_Perf_Stats.sql
@@ -782,33 +782,6 @@ CREATE PROCEDURE #sp_perf_stats_infrequent @runtime datetime, @prevruntime datet
     IF @queryduration > @qrydurationwarnthreshold
       PRINT 'DebugPrint: perfstats2 qry17 - ' + CONVERT (varchar, @queryduration) + 'ms' + CHAR(13) + CHAR(10)
 
-
-    /* Resultset #18:  dm_os_ring_buffers for connectivity
-    ** return all rows on first run and then after only new rows in later runs */
-    PRINT ''
-    RAISERROR ('-- dm_os_ring_buffers --', 0, 1) WITH NOWAIT;
-    SET @querystarttime = GETDATE()
-
-    SET @sql = '
-      SELECT /*' + @procname + ':18*/  
-          CONVERT (varchar(30), @runtime, 126) AS runtime, 
-      CONVERT (varchar(23), DATEADD (ms, -1 * (@MSTICKS - [timestamp]), @mstickstime), 126) AS EventTime, 
-      [record] 
-        FROM sys.dm_os_ring_buffers 
-        WHERE ring_buffer_type in (''RING_BUFFER_CONNECTIVITY'',''RING_BUFFER_SECURITY_ERROR'')
-          AND [timestamp] > @lastmsticks 
-        ORDER BY [timestamp]'
-
-    EXEC sp_executesql @sql, N'@runtime datetime, @lastmsticks bigint, @msticks bigint, @mstickstime datetime', @runtime = @runtime, @lastmsticks = @lastmsticks, @msticks = @msticks, @mstickstime = @mstickstime
-
-
-    RAISERROR (' ', 0, 1) WITH NOWAIT;
-    SET @queryduration = DATEDIFF (ms, @querystarttime, GETDATE())
-    SET @lastmsticks = @msticks
-    IF @queryduration > @qrydurationwarnthreshold
-      PRINT 'DebugPrint: perfstats2 qry18 - ' + CONVERT (varchar, @queryduration) + 'ms' + CHAR(13) + CHAR(10)
-
-
     /* Resultset #19: Plan Cache Stats */
     PRINT ''
     RAISERROR ('-- Plan Cache Stats --', 0, 1) WITH NOWAIT;

--- a/LinuxDiag/SQL_Perf_Stats_Snapshot.sql
+++ b/LinuxDiag/SQL_Perf_Stats_Snapshot.sql
@@ -535,7 +535,7 @@ BEGIN
 
 		--import in SQLNexus	
 		print '-- top 10 CPU by query_hash --'
-		select getdate() as runtime, *  --into tbl_QueryHashByCPU
+		select /*getdate() as runtime,*/ *  --into tbl_QueryHashByCPU
 		from
 		(
 		SELECT TOP 10 query_hash, COUNT (distinct query_plan_hash) as 'distinct query_plan_hash count',
@@ -560,7 +560,7 @@ BEGIN
 
 		--import in SQLNexus
 		print '-- top 10 logical reads by query_hash --'
-		select getdate() as runtime, *  --into tbl_QueryHashByLogicalReads
+		select /*getdate() as runtime,*/ *  --into tbl_QueryHashByLogicalReads
 		from
 		(
 		SELECT TOP 10 query_hash, 
@@ -583,7 +583,7 @@ BEGIN
 
 		--import in SQLNexus
 		print '-- top 10 elapsed time by query_hash --'
-		select getdate() as runtime, * -- into tbl_QueryHashByElapsedTime
+		select /*getdate() as runtime,*/ * -- into tbl_QueryHashByElapsedTime
 		from
 		(
 		SELECT TOP 10 query_hash, 
@@ -606,7 +606,7 @@ BEGIN
 
 		--import in SQLNexus
 		print '-- top 10 CPU by query_plan_hash and query_hash --'
-		SELECT TOP 10 getdate() as runtime, query_plan_hash, query_hash, 
+		SELECT TOP 10 /*getdate() as runtime,*/ query_plan_hash, query_hash, 
 		COUNT (distinct query_plan_hash) as 'distinct query_plan_hash count',
 		sum(execution_count) as 'execution_count', 
 			sum(total_worker_time) as 'total_worker_time',
@@ -626,7 +626,7 @@ BEGIN
 
 		--import in SQLNexus
 		print '-- top 10 logical reads by query_plan_hash and query_hash --'
-		SELECT TOP 10 getdate() as runtime, query_plan_hash, query_hash, sum(execution_count) as 'execution_count',  
+		SELECT TOP 10 /*getdate() as runtime,*/ query_plan_hash, query_hash, sum(execution_count) as 'execution_count',  
 			sum(total_worker_time) as 'total_worker_time',
 			SUM(total_elapsed_time) as 'total_elapsed_time',
 			SUM (total_logical_reads) as 'total_logical_reads',
@@ -643,7 +643,7 @@ BEGIN
 
 		--import in SQLNexus
 		print '-- top 10 elapsed time  by query_plan_hash and query_hash --'
-		SELECT TOP 10 getdate() as runtime, query_plan_hash, query_hash, sum(execution_count) as 'execution_count', 
+		SELECT TOP 10 /*getdate() as runtime,*/ query_plan_hash, query_hash, sum(execution_count) as 'execution_count', 
 			sum(total_worker_time) as 'total_worker_time',
 			SUM(total_elapsed_time) as 'total_elapsed_time',
 			SUM (total_logical_reads) as 'total_logical_reads',

--- a/LinuxDiag/collect_machineconfig.sh
+++ b/LinuxDiag/collect_machineconfig.sh
@@ -65,11 +65,11 @@ function Capture_network_info()
 
 function capture_disk_info()
 {
-	capture_system_info_command "Disk Information" "lsblk -o NAME,MAJ:MIN,FSTYPE,MOUNTPOINT,PARTLABEL,SIZE,ALIGNMENT,PHY-SEC,LOG-SEC,MIN-IO,OPT-IO,ROTA,TYPE,RQ-SIZE,LABEL,MODEL,REV,VENDOR 2>/dev/null" 
-	capture_system_info_command "Disk Related Information" "blockdev --report 2>/dev/null"
-    capture_system_info_command "Disk Space Information" "df -TH 2>/dev/null"
-	capture_system_info_command "Disk Space Information" "fdisk -l 2>/dev/null"
 	capture_system_info_command "Checking Disk FUA Support" "dmesg 2>/dev/null | grep -i fua"
+	capture_system_info_command "Disk Information, lsblk" "lsblk -o NAME,MAJ:MIN,FSTYPE,MOUNTPOINT,PARTLABEL,SIZE,ALIGNMENT,PHY-SEC,LOG-SEC,MIN-IO,OPT-IO,ROTA,TYPE,RQ-SIZE,LABEL,MODEL,REV,VENDOR 2>/dev/null" 
+	capture_system_info_command "Disk Space Information, fdisk -l" "fdisk -l 2>/dev/null"
+    capture_system_info_command "Disk Space Information, df -TH" "df -TH 2>/dev/null"
+	capture_system_info_command "Disk blockdev report Information" "blockdev --report 2>/dev/null"
 }
 
 
@@ -217,7 +217,7 @@ if [ "${is_host_instnace_service_active}" == "YES" ]; then
 fi
 
 echo "======CGroup top======" >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info
-echo -e "\x1B[4mControl Group                                                                                 Tasks   %CPU   Memory  Input/s Output/s\x1B[0m" >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info
+echo -e "\x1B[4mControl Group                                                                                 Tasks   %CPU   Memory  Input/s Output/s\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info 
 systemd-cgtop -m -n 1 2>/dev/null >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info
 echo "" >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info
 
@@ -226,7 +226,7 @@ grep cgroup /proc/filesystems 2>/dev/null >> $outputdir/${HOSTNAME}_os_systemd_c
 echo "" >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info
 
 echo "======top======" >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info
-top -n 1 >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info
+top -n 1 -b >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info
 echo "" >> $outputdir/${HOSTNAME}_os_systemd_cgroup_top.info
 
 

--- a/LinuxDiag/collect_os_ad_logs.sh
+++ b/LinuxDiag/collect_os_ad_logs.sh
@@ -80,7 +80,7 @@ else
     if [ -e "/etc/krb5.conf" ]; then
         DEFAULT_LOG=$(get_conf_optionx '/etc/krb5.conf' 'logging' 'default' 'FILE:/var/log/krb5/krb5kdc.log') | cut -d ":" -f2 | cut -d "=" -f2
         KDC_LOG=$(get_conf_optionx '/etc/krb5.conf' 'logging' 'kdc' 'FILE:/var/log/krb5/krb5kdc.log') | cut -d ":" -f2 | cut -d "=" -f2
-        ADMIN_SERVER_LOG=$(get_conf_optionx '/etc/krb5.conf' 'logging' 'admin_server ' 'FILE:/var/log/krb5/krb5kdc.log') | cut -d ":" -f2 | cut -d "=" -f2
+        ADMIN_SERVER_LOG=$(get_conf_optionx '/etc/krb5.conf' 'logging' 'admin_server' 'FILE:/var/log/krb5/krb5kdc.log') | cut -d ":" -f2 | cut -d "=" -f2
     fi
 
     sh -c 'tar -cjf "$0/$3_os_krb5_$1.tar.bz2" /var/lib/sss/pubconf/krb5.include.d/* "${KRB5_TRACE}" "@{DEFAULT_LOG}" "${KDC_LOG}" "${ADMIN_SERVER_LOG}" --ignore-failed-read --absolute-names 2>/dev/null'  "$outputdir" "$NOW" "$SYSLOGPATH" "$HOSTNAME"

--- a/LinuxDiag/collect_os_logs.sh
+++ b/LinuxDiag/collect_os_logs.sh
@@ -29,15 +29,15 @@ if (echo "$(readlink /sbin/init)" | grep systemd >/dev/null 2>&1); then
 	# Tar command zips all log files specified, to add any other log files add to end of the command.
 	case $linuxdistro in
 	"ubuntu" | "debian")
-		sh -c 'tar -cjf "$0/$3_os_syslogs_$1.tar.bz2" $2/syslog* $2/kern* $2/auth*.* $2/dpkg* --ignore-failed-read --absolute-names 2>/dev/null' "$outputdir" "$NOW" "$SYSLOGPATH" "$HOSTNAME"
+		sh -c 'tar -cjf "$0/$3_os_syslogs_$1.tar.bz2" $2/syslog* $2/sysstat/* $2/kern* $2/auth*.* $2/dpkg* --ignore-failed-read --absolute-names 2>/dev/null' "$outputdir" "$NOW" "$SYSLOGPATH" "$HOSTNAME"
 		;;
 	
 	"rhel" | "centos")
-		sh -c 'tar -cjf "$0/$3_os_syslogs_$1.tar.bz2" $2/message* $2/cron* $2/secure* $2/kdump* $2/boot.log $2/yum* $2/dnf* --ignore-failed-read --absolute-names 2>/dev/null' "$outputdir" "$NOW" "$SYSLOGPATH" "$HOSTNAME"
+		sh -c 'tar -cjf "$0/$3_os_syslogs_$1.tar.bz2" $2/message* $2/sa/* $2/cron* $2/secure* $2/kdump* $2/boot.log $2/yum* $2/dnf* --ignore-failed-read --absolute-names 2>/dev/null' "$outputdir" "$NOW" "$SYSLOGPATH" "$HOSTNAME"
 		;;
 
 	"sles" | "suse" )
-		sh -c 'tar -cjf "$0/$3_os_syslogs_$1.tar.bz2" $2/message* $2/cron* $2/secure* $2/kdump* $2/warn* $2/boot.log $2/zypper* --ignore-failed-read --absolute-names 2>/dev/null' "$outputdir" "$NOW" "$SYSLOGPATH" "$HOSTNAME"
+		sh -c 'tar -cjf "$0/$3_os_syslogs_$1.tar.bz2" $2/message* $2/sa/* $2/cron* $2/secure* $2/kdump* $2/warn* $2/boot.log $2/zypper* --ignore-failed-read --absolute-names 2>/dev/null' "$outputdir" "$NOW" "$SYSLOGPATH" "$HOSTNAME"
 		;;
 	*) ;;
 

--- a/LinuxDiag/collect_sql_ad_logs.sh
+++ b/LinuxDiag/collect_sql_ad_logs.sh
@@ -25,53 +25,55 @@ dockerid=$1
 dockername=$2
 
 echo -e "$(date -u +"%T %D") Collecting ad logs from container instance $dockername..." | tee -a $pssdiag_log	
-docker_has_mssql_keytab=$(docker exec --user root ${dockername} sh -c "(ls /var/opt/mssql/secrets/mssql.keytab >> /dev/null 2>&1 && echo YES) || echo NO")
-if [[ "${docker_has_mssql_keytab}" == "NO" ]]; then
-	echo -e "$(date -u +"%T %D") skipping collecting ad logs, there is no mssql.keytab file for container instance $dockername..." | tee -a $pssdiag_log
-else
-	#Collect krb5.conf from container
-	krb5file=$(docker container inspect -f '{{range .Mounts}}{{printf "\n"}}{{.Destination}}{{end}}' ${dockername} | grep -e krb5.conf)
-	if [[ "${krb5file}" ]]; then
-		echo -e "$(date -u +"%T %D") Collecting krb5.conf file from container : $dockername..." | tee -a $pssdiag_log
-		docker cp $dockerid:$krb5file $outputdir/${dockername}_container_instance_krb5.conf | 2>/dev/null
-	else	
-		echo -e "$(date -u +"%T %D") Container ${dockername} has no krb5.conf... " | tee -a $pssdiag_log
-	fi
 
-	#Creating log file
-	infolog_filename=$outputdir/${dockername}_container_instance_kerberos.info
+#Check if we have configuration files. default container deployment with no mounts do not have /var/opt/mssql/mssql.conf so we need to check this upfront. 
+docker_has_mssqlconf=$(docker exec --user root ${dockername} sh -c "(ls /var/opt/mssql/mssql.conf >> /dev/null 2>&1 && echo YES) || echo NO")
+if [[ "${docker_has_mssqlconf}" == "YES" ]]; then
+SQL_SERVICE_KEYTAB_FILE=$(get_docker_conf_optionx '/var/opt/mssql/mssql.conf' 'network' 'kerberoskeytabfile' '' $dockername)
+docker_has_mssql_keytab=$(docker exec --user root ${dockername} sh -c "(ls ${SQL_SERVICE_KEYTAB_FILE} >> /dev/null 2>&1 && echo YES) || echo NO")
+    if [[ "${docker_has_mssql_keytab}" == "NO" ]]; then
+        echo -e "$(date -u +"%T %D") skipping collecting ad logs, there is no mssql.keytab file for container instance $dockername..." | tee -a $pssdiag_log
+    else
+        #Collect krb5.conf from container
+        krb5file=$(docker container inspect -f '{{range .Mounts}}{{printf "\n"}}{{.Destination}}{{end}}' ${dockername} | grep -e krb5.conf)
+        if [[ "${krb5file}" ]]; then
+            echo -e "$(date -u +"%T %D") Collecting krb5.conf file from container : $dockername..." | tee -a $pssdiag_log
+            docker cp $dockerid:$krb5file $outputdir/${dockername}_container_instance_krb5.conf | 2>/dev/null
+        else	
+            echo -e "$(date -u +"%T %D") Container ${dockername} has no krb5.conf... " | tee -a $pssdiag_log
+        fi
 
-	#Collect resolv.conf from container
-	echo -e "$(date -u +"%T %D") Collecting resolv.conf from container instance $dockername..." | tee -a $pssdiag_log
-	capture_system_info_command "cat /etc/resolv.conf" "docker exec --user root "${dockername}" sh -c \"cat /etc/resolv.conf\""
+        #Creating log file
+        infolog_filename=$outputdir/${dockername}_container_instance_kerberos.info
 
-	#Collecting mssql.keytab klist information
-	echo "$(date -u +"%T %D") Collecting mssql.keytab klist information from container instance $dockername..."
-	tmpcontainertmpfile="./$(uuidgen).pssdiag.mssql.keytab"
-	docker cp $dockerid:/var/opt/mssql/secrets/mssql.keytab ${tmpcontainertmpfile} | 2>/dev/null
-	capture_system_info_command "klist -kte /var/opt/mssql/secrets/mssql.keytab" "klist -kte ${tmpcontainertmpfile}"
-	rm "$tmpcontainertmpfile"
+        #Collect resolv.conf from container
+        echo -e "$(date -u +"%T %D") Collecting resolv.conf from container instance $dockername..." | tee -a $pssdiag_log
+        capture_system_info_command "cat /etc/resolv.conf" "docker exec --user root "${dockername}" sh -c \"cat /etc/resolv.conf\""
 
-	#Collecting service account kvno information
-	#Check if we have configuration files. default container deployment with no mounts do not have /var/opt/mssql/mssql.conf so we need to check this upfront. 
-	docker_has_mssqlconf=$(docker exec --user root ${dockername} sh -c "(ls /var/opt/mssql/mssql.conf >> /dev/null 2>&1 && echo YES) || echo NO")
-	#Collecting errorlog
-	if [[ "${docker_has_mssqlconf}" == "YES" ]]; then
-		echo -e "$(date -u +"%T %D") Collecting service account kvno information from container instance $dockername..." | tee -a $pssdiag_log
-		SQL_SERVICE_ACCOUNT_KVNO=$(get_docker_conf_optionx '/var/opt/mssql/mssql.conf' 'network' 'privilegedadaccount' '' $dockername)
-	fi
-	if [ "${linuxdistro}" == "sles" ];then
-		capture_system_info_command "Sql Service account /usr/lib/mit/bin/kvno: /usr/lib/mit/bin/kvno ${SQL_SERVICE_ACCOUNT_KVNO}" "/usr/lib/mit/bin/kvno ${SQL_SERVICE_ACCOUNT_KVNO}"
-	else
-		capture_system_info_command "Sql Service account kvno: kvno ${SQL_SERVICE_ACCOUNT_KVNO}" "kvno ${SQL_SERVICE_ACCOUNT_KVNO}"
-	fi
+        #Collecting mssql.keytab klist information
+        echo "$(date -u +"%T %D") Collecting mssql.keytab klist information from container instance $dockername..."
+        tmpcontainertmpfile="./$(uuidgen).pssdiag.mssql.keytab"
+        docker cp $dockerid:${SQL_SERVICE_KEYTAB_FILE} ${tmpcontainertmpfile} | 2>/dev/null
+        capture_system_info_command "klist -kte ${tmpcontainertmpfile}" "klist -kte ${SQL_SERVICE_KEYTAB_FILE}"
+        rm "$tmpcontainertmpfile"
 
-	#check if krb5 logging was enabled at service level for container instance 
-	SQL_CONTAINER_KRB5_TRACE=$(docker exec --user root ${dockername} env | grep "KRB5_TRACE" | grep KRB5_TRACE | sed -e "s/^KRB5_TRACE=//")
-	if [ -e "${SQL_CONTAINER_KRB5_TRACE}" ]; then
-		echo -e "$(date -u +"%T %D") Collecting sql service krb5 trace from container instance : ${HOSTNAME}..." | tee -a $pssdiag_log
-		docker cp $dockerid:$SQL_CONTAINER_KRB5_TRACE $outputdir/${dockername}_container_instance_$(basename ${SQL_CONTAINER_KRB5_TRACE}) | 2>/dev/null
-	fi
+        #Collecting service account kvno information     
+        echo -e "$(date -u +"%T %D") Collecting service account kvno information from container instance $dockername..." | tee -a $pssdiag_log
+        SQL_SERVICE_ACCOUNT_KVNO=$(get_docker_conf_optionx '/var/opt/mssql/mssql.conf' 'network' 'privilegedadaccount' '' $dockername)
+        
+        if [ "${linuxdistro}" == "sles" ];then
+            capture_system_info_command "Sql Service account /usr/lib/mit/bin/kvno: /usr/lib/mit/bin/kvno ${SQL_SERVICE_ACCOUNT_KVNO}" "/usr/lib/mit/bin/kvno ${SQL_SERVICE_ACCOUNT_KVNO}"
+        else
+            capture_system_info_command "Sql Service account kvno: kvno ${SQL_SERVICE_ACCOUNT_KVNO}" "kvno ${SQL_SERVICE_ACCOUNT_KVNO}"
+        fi
+
+        #check if krb5 logging was enabled at service level for container instance 
+        SQL_CONTAINER_KRB5_TRACE=$(docker exec --user root ${dockername} env | grep "KRB5_TRACE" | grep KRB5_TRACE | sed -e "s/^KRB5_TRACE=//")
+        if [ -e "${SQL_CONTAINER_KRB5_TRACE}" ]; then
+            echo -e "$(date -u +"%T %D") Collecting sql service krb5 trace from container instance : ${HOSTNAME}..." | tee -a $pssdiag_log
+            docker cp $dockerid:$SQL_CONTAINER_KRB5_TRACE $outputdir/${dockername}_container_instance_$(basename ${SQL_CONTAINER_KRB5_TRACE}) | 2>/dev/null
+        fi
+    fi
 fi
 }
 
@@ -131,19 +133,23 @@ if [[ "$COLLECT_HOST_SQL_INSTANCE" = "YES" ]]; then
 	get_host_instance_status
 	#only check if its installed, if its installed then regradlesss if its active or note we need to collect the logs 
 	if [ "${is_host_instance_service_installed}" == "YES" ]; then
-		echo -e "$(date -u +"%T %D") collecting ad logs from host instance ${HOSTNAME}..." | tee -a $pssdiag_log
+		echo -e "$(date -u +"%T %D") Collecting ad logs from host instance ${HOSTNAME}..." | tee -a $pssdiag_log
 
 		infolog_filename=$outputdir/${HOSTNAME}_host_intance_Kerberos.info
 
-		if [ ! -e "/var/opt/mssql/secrets/mssql.keytab" ]; then
-			echo -e "$(date -u +"%T %D") skipping collecting ad logs, there is no mssql.keytab file for host instance : ${HOSTNAME}..." | tee -a $pssdiag_log
-		else
-			#Capture mssql.keytab klist information
-			echo -e "$(date -u +"%T %D") Collecting mssql.keytab klist information from host instance : ${HOSTNAME}..." | tee -a $pssdiag_log
-			capture_system_info_command "klist -kte /var/opt/mssql/secrets/mssql.keytab" "klist -kte /var/opt/mssql/secrets/mssql.keytab"
-			# Capture service account knvo info
-			echo -e "$(date -u +"%T %D") Collecting service account kvno information from host instance : ${HOSTNAME}..." | tee -a $pssdiag_log
-			if [ -e "/var/opt/mssql/mssql.conf" ]; then
+		if [ -e "/var/opt/mssql/mssql.conf" ]; then
+
+			SQL_SERVICE_KEYTAB_FILE=$(get_conf_optionx '/var/opt/mssql/mssql.conf' 'network' 'kerberoskeytabfile' '')
+
+			if [ ! -e ${SQL_SERVICE_KEYTAB_FILE} ]; then
+				echo -e "$(date -u +"%T %D") skipping collecting ad logs, there is no mssql.keytab file for host instance : ${HOSTNAME}..." | tee -a $pssdiag_log
+			else
+				#Capture mssql.keytab klist information
+				echo -e "$(date -u +"%T %D") Collecting mssql.keytab klist information from host instance : ${HOSTNAME}..." | tee -a $pssdiag_log
+				capture_system_info_command "klist -kte ${SQL_SERVICE_KEYTAB_FILE}" "klist -kte ${SQL_SERVICE_KEYTAB_FILE}"
+				
+				# Capture service account knvo info
+				echo -e "$(date -u +"%T %D") Collecting service account kvno information from host instance : ${HOSTNAME}..." | tee -a $pssdiag_log
 				SQL_SERVICE_ACCOUNT_KVNO=$(get_conf_optionx '/var/opt/mssql/mssql.conf' 'network' 'privilegedadaccount' '')
 				linuxdistro=`cat /etc/os-release | grep -i '^ID=' | head -n1 | awk -F'=' '{print $2}' | sed 's/"//g'`
 				if [ "${linuxdistro}" == "sles" ];then
@@ -151,13 +157,13 @@ if [[ "$COLLECT_HOST_SQL_INSTANCE" = "YES" ]]; then
 				else
 					capture_system_info_command "Sql Service account kvno: kvno ${SQL_SERVICE_ACCOUNT_KVNO}" "kvno ${SQL_SERVICE_ACCOUNT_KVNO}"
 				fi
-			fi
-			#check if krb5 logging was enabled at service level for host instance
-			if (systemctl -q is-enabled mssql-server); then
-				SQL_HOST_KRB5_TRACE=$(systemctl cat mssql-server.service | grep KRB5_TRACE | sed -e "s/^Environment=KRB5_TRACE=//")
-				if [ -e "${SQL_HOST_KRB5_TRACE}" ]; then
-					echo -e "$(date -u +"%T %D") Collecting sql service krb5 trace from host instance : ${HOSTNAME}..." | tee -a $pssdiag_log
-					cat "${SQL_HOST_KRB5_TRACE}" > $outputdir/${HOSTNAME}_host_instance_$(basename ${SQL_HOST_KRB5_TRACE})
+				#check if krb5 logging was enabled at service level for host instance
+				if (systemctl -q is-enabled mssql-server); then
+					SQL_HOST_KRB5_TRACE=$(systemctl cat mssql-server.service | grep KRB5_TRACE | sed -e "s/^Environment=KRB5_TRACE=//")
+					if [ -e "${SQL_HOST_KRB5_TRACE}" ]; then
+						echo -e "$(date -u +"%T %D") Collecting sql service krb5 trace from host instance : ${HOSTNAME}..." | tee -a $pssdiag_log
+						cat "${SQL_HOST_KRB5_TRACE}" > $outputdir/${HOSTNAME}_host_instance_$(basename ${SQL_HOST_KRB5_TRACE})
+					fi
 				fi
 			fi
 		fi

--- a/LinuxDiag/start_collector.sh
+++ b/LinuxDiag/start_collector.sh
@@ -309,7 +309,7 @@ if [[ -z "$authentication_mode" ]] && [[ "$is_instance_inside_container_active" 
 	echo    "+---+-----------------------+------------------------------------------------------------------------------+"
 	echo    "|No |Authentication Mode    |Description                                                                   |"
 	echo    "+---+-----------------------+------------------------------------------------------------------------------+"
-	echo -e "| 1 |SQL                    |Use SQL Athentication. \x1B[34m(Default)\x1B[0m                                              |"
+	echo -e "| 1 |SQL                    |Use SQL Authentication. \x1B[34m(Default)\x1B[0m                                              |"
 	echo    "+---+-----------------------+------------------------------------------------------------------------------+"
 	echo    "| 2 |AD                     |Use AD Authentication                                                         |"
 	echo    "+---+-----------------------+------------------------------------------------------------------------------+"
@@ -480,7 +480,7 @@ pssdiag_log="$outputdir/pssdiag.log"
 mkdir -p $working_dir/output
 chmod a+w $working_dir/output
 cp pssdiag*.conf $working_dir/output
-echo -e "\x1B[2;34m============================================================================================================\x1B[0m" >> $pssdiag_log
+echo -e "\x1B[2;34m============================================================================================================\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 echo -e "$(date -u +"%T %D") Executing PSSDiag on ${HOSTNAME}"  >> $pssdiag_log
 echo -e "$(date -u +"%T %D") Scenario file used ${scenario}" >> $pssdiag_log
 echo -e "$(date -u +"%T %D") Authentication mode used ${authentication_mode}" >> $pssdiag_log
@@ -499,7 +499,7 @@ echo "$(date -u +"%T %D") is using podamn without docker engine? ${is_podman_sql
 echo "$(date -u +"%T %D") Are we running inside container? ${is_instance_inside_container_active}" >> $pssdiag_log
 echo "$(date -u +"%T %D") PSSDiag version? ${script_version}" >> $pssdiag_log
 echo "$(date -u +"%T %D") BASH_VERSION? ${BASH_VERSION}" >> $pssdiag_log
-echo -e "\x1B[2;34m============================================= Starting PSSDiag =============================================\x1B[0m" | tee -a $pssdiag_log
+echo -e "\x1B[2;34m============================================= Starting PSSDiag =============================================\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 
 
 # if we just need a snapshot of logs, we do not need to invoke background collectors
@@ -548,11 +548,11 @@ if [[ "$COLLECT_HOST_SQL_INSTANCE" == "YES" ]];then
 		SQL_LISTEN_PORT=$(get_sql_listen_port "host_instance")
 		#SQL_SERVER_NAME="$HOSTNAME,$SQL_LISTEN_PORT"
 		echo -e "" | tee -a $pssdiag_log
-		echo -e "\x1B[7mCollecting startup information from host instance $HOSTNAME and port ${SQL_LISTEN_PORT}...\x1B[0m" | tee -a $pssdiag_log
+		echo -e "\x1B[7mCollecting startup information from host instance $HOSTNAME and port ${SQL_LISTEN_PORT}...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 		sql_connect "host_instance" "${HOSTNAME}" "${SQL_LISTEN_PORT}" "${authentication_mode}"
 		sqlconnect=$?
 		if [[ $sqlconnect -ne 1 ]]; then
-			echo -e "\x1B[31mTesting the connection to host instance using $authentication_mode authentication failed." | tee -a $pssdiag_log
+			echo -e "\x1B[31mTesting the connection to host instance using $authentication_mode authentication failed." | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 			echo -e "Please refer to the above lines for errors...\x1B[0m" | tee -a $pssdiag_log
 		else
 			sql_collect_perfstats "${HOSTNAME}" "host_instance"
@@ -577,12 +577,12 @@ if [[ "$COLLECT_HOST_SQL_INSTANCE" == "YES" ]];then
 	if [ "${is_instance_inside_container_active}" == "YES" ]; then
 	    SQL_SERVER_NAME="$HOSTNAME,1433"
 		echo -e "" | tee -a $pssdiag_log
-		echo -e "\x1B[7mCollecting startup information from instance $HOSTNAME and port 1433...\x1B[0m" | tee -a $pssdiag_log
+		echo -e "\x1B[7mCollecting startup information from instance $HOSTNAME and port 1433...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 		sql_connect "instance" "${HOSTNAME}" "1433" "${authentication_mode}"
 		sqlconnect=$?
 		if [[ $sqlconnect -ne 1 ]]; then
-			echo -e "\x1B[31mTesting the connection to instance using $authentication_mode authentication failed." | tee -a $pssdiag_log
-			echo -e "Please refer to the above lines for errors...\x1B[0m" | tee -a $pssdiag_log
+			echo -e "\x1B[31mTesting the connection to instance using $authentication_mode authentication failed." | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
+			echo -e "Please refer to the above lines for errors...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 		else
 			sql_collect_perfstats "${HOSTNAME}" "instance"
 			sql_collect_counters "${HOSTNAME}" "instance"
@@ -608,12 +608,12 @@ if [[ "$COLLECT_CONTAINER" != "NO" ]]; then
             get_docker_mapped_port "${dockerid}"
  	        #SQL_SERVER_NAME="$dockername,$dockerport"
 			echo -e "" | tee -a $pssdiag_log
-			echo -e "\x1B[7mCollecting startup information from container instance ${dockername} and port ${dockerport}\x1B[0m" | tee -a $pssdiag_log
+			echo -e "\x1B[7mCollecting startup information from container instance ${dockername} and port ${dockerport}\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 	        sql_connect "container_instance" "${dockername}" "${dockerport}" "${authentication_mode}"
         	sqlconnect=$?
 	        if [[ $sqlconnect -ne 1 ]]; then
-        	        echo -e "\x1B[31mTesting the connection to container instance using $authentication_mode authentication failed." | tee -a $pssdiag_log
-					echo -e "Please refer to the above lines for errors...\x1B[0m" | tee -a $pssdiag_log
+        	        echo -e "\x1B[31mTesting the connection to container instance using $authentication_mode authentication failed." | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
+					echo -e "Please refer to the above lines for errors...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 	        else
            	    sql_collect_perfstats "${dockername}" "container_instance"      
 				sql_collect_counters "${dockername}" "container_instance"
@@ -635,12 +635,12 @@ if [[ "$COLLECT_CONTAINER" != "NO" ]]; then
                 	get_docker_mapped_port "${dockerid}"
 	                #SQL_SERVER_NAME="$dockername,$dockerport"
 					echo -e ""  | tee -a $pssdiag_log
-					echo -e "\x1B[7mCollecting startup information from container_instance ${dockername} and port ${dockerport}\x1B[0m" | tee -a $pssdiag_log
+					echo -e "\x1B[7mCollecting startup information from container_instance ${dockername} and port ${dockerport}\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 	                sql_connect "container_instance" "${dockername}" "${dockerport}" "${authentication_mode}"
         	        sqlconnect=$?
                 	if [[ $sqlconnect -ne 1 ]]; then
-                        	echo -e "\x1B[31mTesting the connection to container instance using $authentication_mode authentication failed." | tee -a $pssdiag_log
-							echo -e "Please refer to the above lines for connectivity and authentication errors...\x1B[0m" | tee -a $pssdiag_log
+                        	echo -e "\x1B[31mTesting the connection to container instance using $authentication_mode authentication failed." | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
+							echo -e "Please refer to the above lines for connectivity and authentication errors...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 	                else
 						sql_collect_perfstats "${dockername}" "container_instance"
                 	    sql_collect_counters "${dockername}" "container_instance"
@@ -667,16 +667,16 @@ printf "%s\n" "$anchorpid" >> $outputdir/pssdiag_stoppids_os_collectors.txt
 pgrep -P $anchorpid  >> $outputdir/pssdiag_stoppids_os_collectors.txt
 # anchor
 
-echo -e "\x1B[2;34m==============================  Startup Completd, Data Collection in Progress ==============================\x1B[0m" | tee -a $pssdiag_log
+echo -e "\x1B[2;34m==============================  Startup Completd, Data Collection in Progress ==============================\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 echo -e "" | tee -a $pssdiag_log
-echo -e "\033[0;33m############################################################################################################\033[0;31m" | tee -a $pssdiag_log
-echo -e "\033[0;33m#                 Please reproduce the problem now and then stop data collection afterwards                #\033[0;31m" | tee -a $pssdiag_log
-echo -e "\033[0;33m############################################################################################################\033[0;31m" | tee -a $pssdiag_log
+echo -e "\033[0;33m############################################################################################################\033[0;31m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
+echo -e "\033[0;33m#                 Please reproduce the problem now and then stop data collection afterwards                #\033[0;31m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
+echo -e "\033[0;33m############################################################################################################\033[0;31m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 echo -e "" | tee -a $pssdiag_log
 if [ "${is_instance_inside_container_active}" == "NO" ]; then
-	echo -e "\033[1;33m    Performance collectors have started in the background. to stop them run 'sudo ./stop_collector.sh'...   \033[0m" | tee -a $pssdiag_log
+	echo -e "\033[1;33m    Performance collectors have started in the background. to stop them run 'sudo ./stop_collector.sh'...   \033[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 else
-	echo -e "\033[1;33m    Performance collectors have started in the background. to stop them run './stop_collector.sh'...   \033[0m" | tee -a $pssdiag_log
+	echo -e "\033[1;33m    Performance collectors have started in the background. to stop them run './stop_collector.sh'...   \033[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 fi
 echo -e "" | tee -a $pssdiag_log
 exit 0

--- a/LinuxDiag/stop_collector.sh
+++ b/LinuxDiag/stop_collector.sh
@@ -88,7 +88,7 @@ pssdiag_inside_container_get_instance_status
 
 #Checks: make sure we have a valid authentication entered, we are running with system that has systemd
 if [[ ! -z "$authentication_mode" ]] && [[ $is_instance_inside_container_active == "NO" ]] && [[ "$authentication_mode" != "SQL" ]] && [[ "$authentication_mode" != "AD" ]] && [[ "$authentication_mode" != "NONE" ]]; then
-	echo -e "\x1B[33mwarning: wrong authentication mode (first argument passed to PSSDiag)\x1B[0m"
+	echo -e "\x1B[33mwarning: Invalid authentication mode (first argument passed to PSSDiag)\x1B[0m"
 	echo "" 
 	echo "Valid options are:" 
 	echo "  SQL"
@@ -101,7 +101,7 @@ fi
 
 #Checks: make sure we have a valid authentication entered, we are running with system that has no systemd
 if [[ ! -z "$authentication_mode" ]] && [[ $is_instance_inside_container_active == "YES" ]] && [[ "$authentication_mode" != "SQL" ]]; then
-	echo -e "\x1B[33mwarning: wrong authentication mode (first argument passed to PSSDiag)\x1B[0m"
+	echo -e "\x1B[33mwarning: Invalid authentication mode (first argument passed to PSSDiag)\x1B[0m"
 	echo "" 
 	echo "Valid options are:" 
 	echo "  SQL"
@@ -117,7 +117,7 @@ NOW=`date +"%m_%d_%Y_%H_%M"`
 # kills all the PID's stored in the file
 # after all work is done, remove the PID files
 
-echo -e "\x1B[2;34m============================================= Stopping PSSDiag =============================================\x1B[0m" | tee -a $pssdiag_log
+echo -e "\x1B[2;34m============================================= Stopping PSSDiag =============================================\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 
 if [[ -f $outputdir/pssdiag_stoppids_sql_collectors.txt ]]; then
 	echo "$(date -u +"%T %D") Starting to stop background processes that were collecting sql data..." | tee -a $pssdiag_log
@@ -167,12 +167,12 @@ if [[ "$COLLECT_HOST_SQL_INSTANCE" == "YES" ]];then
                 SQL_LISTEN_PORT=$(get_sql_listen_port "host_instance")
                 SQL_SERVER_NAME="$HOSTNAME,$SQL_LISTEN_PORT"
                 echo -e "" | tee -a $pssdiag_log
-                echo -e "\x1B[7mCollecting information from host instance $HOSTNAME and port $SQL_LISTEN_PORT...\x1B[0m" | tee -a $pssdiag_log
+                echo -e "\x1B[7mCollecting information from host instance $HOSTNAME and port $SQL_LISTEN_PORT...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
                 sql_connect "host_instance" "${HOSTNAME}" "${SQL_LISTEN_PORT}" "${authentication_mode}"
                 sqlconnect=$?
                 if [[ $sqlconnect -ne 1 ]]; then
-        	        echo -e "\x1B[31mTesting the connection to host instance using $authentication_mode authentication failed." | tee -a $pssdiag_log
-			echo -e "Please refer to the above lines for errors...\x1B[0m" | tee -a $pssdiag_log
+        	        echo -e "\x1B[31mTesting the connection to host instance using $authentication_mode authentication failed." | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
+			echo -e "Please refer to the above lines for errors...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
                 else
                         sql_stop_xevent "${HOSTNAME}" "host_instance" 
                         sql_stop_trace "${HOSTNAME}" "host_instance" 
@@ -196,12 +196,12 @@ if [[ "$COLLECT_HOST_SQL_INSTANCE" == "YES" ]];then
 	if [ "${is_instance_inside_container_active}" == "YES" ]; then
                 SQL_SERVER_NAME="$HOSTNAME,1433"
                 echo -e "" | tee -a $pssdiag_log
-                echo -e "\x1B[7mCollecting information from instance $HOSTNAME and port 1433...\x1B[0m" | tee -a $pssdiag_log
+                echo -e "\x1B[7mCollecting information from instance $HOSTNAME and port 1433...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
                 sql_connect "instance" "${HOSTNAME}" "1433" "${authentication_mode}"
                 sqlconnect=$?
                 if [[ $sqlconnect -ne 1 ]]; then
-        	        echo -e "\x1B[31mTesting the connection to instance using $authentication_mode authentication failed." | tee -a $pssdiag_log
-			echo -e "Please refer to the above lines for errors...\x1B[0m" | tee -a $pssdiag_log
+        	        echo -e "\x1B[31mTesting the connection to instance using $authentication_mode authentication failed." | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
+			echo -e "Please refer to the above lines for errors...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
                 else
                         sql_stop_xevent "${HOSTNAME}" "instance" 
                         sql_stop_trace "${HOSTNAME}" "instance" 
@@ -231,12 +231,12 @@ if [[ "$COLLECT_CONTAINER" != "NO" ]]; then
                         #SQL_SERVER_NAME="$HOSTNAME,$dockerport"    
                         SQL_SERVER_NAME="$dockername,$dockerport"
                         echo -e "" | tee -a $pssdiag_log
-                        echo -e "\x1B[7mCollecting information from container instance ${dockername} and port ${dockerport}\x1B[0m" | tee -a $pssdiag_log
+                        echo -e "\x1B[7mCollecting information from container instance ${dockername} and port ${dockerport}\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
                         sql_connect "container_instance" "${dockername}" "${dockerport}" "${authentication_mode}"
                         sqlconnect=$?
                         if [[ $sqlconnect -ne 1 ]]; then
-                                echo -e "\x1B[31mTesting the connection to container instance using $authentication_mode authentication failed." | tee -a $pssdiag_log
-                                echo -e "Please refer to the above lines for errors...\x1B[0m" | tee -a $pssdiag_log
+                                echo -e "\x1B[31mTesting the connection to container instance using $authentication_mode authentication failed." | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
+                                echo -e "Please refer to the above lines for errors...\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
                         else
                                 sql_stop_xevent "${dockername}" "container_instance" 
                                 sql_stop_trace "${dockername}" "container_instance" 
@@ -260,11 +260,11 @@ if [[ "$COLLECT_CONTAINER" != "NO" ]]; then
                                 get_docker_mapped_port "${dockerid}"
                                 SQL_SERVER_NAME="$dockername,$dockerport"
                                 echo -e "" | tee -a $pssdiag_log
-                                echo -e "\x1B[7mCollecting information from container instance ${dockername} and port ${dockerport}\x1B[0m" | tee -a $pssdiag_log
+                                echo -e "\x1B[7mCollecting information from container instance ${dockername} and port ${dockerport}\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
                                 sql_connect "container_instance" "${dockername}" "${dockerport}" "${authentication_mode}"
                                 sqlconnect=$?
                                 if [[ $sqlconnect -ne 1 ]]; then
-                                        echo -e "\x1B[31mTesting the connection to container instance using $authentication_mode authentication failed." | tee -a $pssdiag_log
+                                        echo -e "\x1B[31mTesting the connection to container instance using $authentication_mode authentication failed." | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
                                         echo -e "Please refer to the above lines for errors...\x1B[0m" | tee -a $pssdiag_log
                                 else
                                         sql_stop_xevent "${dockername}" "container_instance" 
@@ -285,7 +285,7 @@ fi
 
 echo -e "" | tee -a $pssdiag_log
 
-echo -e "\x1B[2;34m======================================== Collecting Static Logs ============================================\x1B[0m" | tee -a $pssdiag_log
+echo -e "\x1B[2;34m======================================== Collecting Static Logs ============================================\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 
 #collect basic machine configuration
 if [[ $COLLECT_OS_CONFIG == "YES" ]]; then
@@ -321,10 +321,10 @@ if [[ "$COLLECT_SQL_SEC_AD_LOGS" == "YES" ]]; then
 	./collect_sql_ad_logs.sh
 fi
 
-echo -e "\x1B[2;34m=======================================  Creating Compressed Archive =======================================\x1B[0m" | tee -a $pssdiag_log
+echo -e "\x1B[2;34m=======================================  Creating Compressed Archive =======================================\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 #zip up output directory
-tar -zcf "output_${HOSTNAME}_${NOW}.tar.bz2" output
+tar -cjf "output_${HOSTNAME}_${NOW}.tar.bz2" output
 echo -e "***Data collected is in the file output_${HOSTNAME}_${NOW}.tar.bz2 ***" | tee -a $pssdiag_log
-echo -e "\x1B[2;34m=================================================== Done ===================================================\x1B[0m" | tee -a $pssdiag_log
+echo -e "\x1B[2;34m=================================================== Done ===================================================\x1B[0m" | sed -e 's/\x1b\[[0-9;]*m//g' | tee -a $pssdiag_log
 
 


### PR DESCRIPTION
- Updated output archive format to .bz2.
- Fixed issue with collecting logs when `mssql-conf` is manually edited without spaces for sections, options and set values.
- Enabled collection of `mssql.keytab` from non-default locations based on `mssql-conf` setting.
- Adjusted PerfStat files to allow import into Nexus.
- Removed ANSI color codes from `pssdiag.log` to correct formatting.
- Removed ANSI color codes from top and cgroup output to correct formatting.
- Enabled collection of historical sar records.
 
